### PR TITLE
fix: Redis SSL configuration

### DIFF
--- a/docs/3-deployment/deployment-on-heroku.rst
+++ b/docs/3-deployment/deployment-on-heroku.rst
@@ -22,9 +22,6 @@ Run these commands to deploy the project to Heroku:
 
     heroku addons:create heroku-redis:mini
 
-    # Enable Redis TLS support (required for new Heroku Redis instances)
-    heroku config:set REDIS_SSL=True
-
     # Assuming you chose Mailgun as mail service (see below for others)
     heroku addons:create mailgun:starter
 

--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -2,6 +2,7 @@
 """Base settings to build other settings files upon."""
 
 from pathlib import Path
+import ssl
 
 import environ
 
@@ -283,9 +284,7 @@ LOGGING = {
 }
 
 REDIS_URL = env("REDIS_URL", default="redis://{% if cookiecutter.use_docker == 'y' %}redis{%else%}localhost{% endif %}:6379/0")
-CELERY_BROKER_USE_SSL = env.bool("REDIS_SSL", default=False)
-CELERY_REDIS_BACKEND_USE_SSL = env.bool("REDIS_SSL", default=False)
-
+REDIS_SSL = REDIS_URL.startswith("rediss://")
 
 {% if cookiecutter.use_celery == 'y' -%}
 # Celery
@@ -295,8 +294,12 @@ if USE_TZ:
     CELERY_TIMEZONE = TIME_ZONE
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-broker_url
 CELERY_BROKER_URL = REDIS_URL
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#redis-backend-use-ssl
+CELERY_BROKER_USE_SSL = {"ssl_cert_reqs": ssl.CERT_NONE} if REDIS_SSL else None
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#std:setting-result_backend
 CELERY_RESULT_BACKEND = REDIS_URL
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#redis-backend-use-ssl
+CELERY_REDIS_BACKEND_USE_SSL = CELERY_BROKER_USE_SSL
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-extended
 CELERY_RESULT_EXTENDED = True
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#result-backend-always-retry

--- a/{{cookiecutter.project_slug}}/config/settings/production.py
+++ b/{{cookiecutter.project_slug}}/config/settings/production.py
@@ -48,20 +48,6 @@ CACHES = {
     },
 }
 
-
-REDIS_URL = env("REDIS_TLS_URL", default=env("REDIS_URL"))
-REDIS_SSL = env.bool("REDIS_SSL", default=False)
-
-CERT_NONE = 0
-
-if REDIS_SSL:
-    CELERY_REDIS_BACKEND_USE_SSL = {"ssl_cert_reqs": CERT_NONE}
-    CELERY_BROKER_USE_SSL = {"ssl_cert_reqs": CERT_NONE}
-    CACHES["default"]["OPTIONS"]["CONNECTION_POOL_CLASS"] = "redis.connection.SSLConnection"
-    CACHES["default"]["OPTIONS"]["SSL_CERT_REQS"] = CERT_NONE
-
-CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP = True
-
 # SECURITY
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#secure-proxy-ssl-header


### PR DESCRIPTION
- Move Redis SSL configuration to base settings
- Remove redundant Redis SSL settings from production
- Remove REDIS_SSL env var from Heroku deployment docs
- Use rediss:// URL scheme detection for SSL

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
