### PR TITLE
Change import ssl settings to conditional

### DIFF
--- a/{{cookiecutter.project_slug}}/config/settings/base.py
+++ b/{{cookiecutter.project_slug}}/config/settings/base.py
@@ -2,9 +2,12 @@
 """Base settings to build other settings files upon."""
 
 from pathlib import Path
-import ssl
 
 import environ
+
+{% if cookiecutter.use_celery == 'y' %}
+import ssl
+{% endif %}
 
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent.parent
 # {{ cookiecutter.project_slug }}/


### PR DESCRIPTION
The ssl module is only used in Celery SSL settings, so it is not actually used when the use_celery option is 'n'. I modified it to import conditionally as follows.

<!-- Thank you for helping us out: your efforts mean a great deal to the project and the community as a whole! -->

## Description

<!-- What's it you're proposing? -->

Checklist:

- [ ] I've made sure that tests are updated accordingly (especially if adding or updating a template option)
- [ ] I've updated the documentation or confirm that my change doesn't require any updates

## Rationale

<!--
Why does this project need the change you're proposing?
If this pull request fixes an open issue, don't forget to link it with `Fix #NNNN`
-->
